### PR TITLE
use fsnotify.v0

### DIFF
--- a/helpers/filesystem.go
+++ b/helpers/filesystem.go
@@ -1,9 +1,10 @@
 package helpers
 
 import (
-	"code.google.com/p/go.exp/fsnotify"
 	"log"
 	"time"
+
+	"gopkg.in/fsnotify.v0"
 )
 
 const Duration = 500 * time.Millisecond


### PR DESCRIPTION
fsnotify is currently being maintained at:
https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.

(So I know when this is merged, ref: https://github.com/go-fsnotify/fsnotify/issues/35)
